### PR TITLE
jest: use factory to create component

### DIFF
--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -2,12 +2,18 @@ import { mount } from '@vue/test-utils';
 import { ModalsPlugin } from '../../lib';
 import UseModalsSample from '../src/components/UseModalsSample.vue';
 
+function factory(config = {}) {
+  return mount(UseModalsSample, config);
+}
+
 it('should install ModalsPlugin and provide modals and modalsInstances', () => {
-  const component = mount(UseModalsSample, {
-    global: {
-      plugins: [ModalsPlugin]
+  const component = factory(
+    {
+      global: {
+        plugins: [ModalsPlugin]
+      }
     }
-  });
+  );
 
   const providedModals = component.vm.$.appContext.provides.modals;
   expect(providedModals).not.toBeUndefined();

--- a/tests/unit/modal-container.test.ts
+++ b/tests/unit/modal-container.test.ts
@@ -6,16 +6,23 @@ import SimpleModal from '../src/components/SimpleModal.vue';
 import PropsModal from '../src/components/PropsModal.vue';
 import ResolveRejectModal from '../src/components/ResolveRejectModal.vue';
 
+
+function factory(config = {}) {
+  return mount(ModalsDispatcher, config);
+}
+
 beforeEach(() => {
   document.body.innerHTML = '';
 })
 
 it('should render Modal Component', async () => {
-  const component = mount(ModalsDispatcher, {
-    global: {
-      plugins: [ModalsPlugin]
+  const component = factory(
+    {
+      global: {
+        plugins: [ModalsPlugin]
+      }
     }
-  });
+  );
 
   const modals = component.vm.$.appContext.provides.modals;
 
@@ -30,11 +37,13 @@ it('should render Modal Component', async () => {
 });
 
 it('should set props Modal Component', async () => {
-  const component = mount(ModalsDispatcher, {
-    global: {
-      plugins: [ModalsPlugin]
+  const component = factory(
+    {
+      global: {
+        plugins: [ModalsPlugin]
+      }
     }
-  });
+  );
 
   const modals = component.vm.$.appContext.provides.modals;
 
@@ -51,11 +60,13 @@ it('should set props Modal Component', async () => {
 describe('rejectOnBackdrop', () => {
   describe('when "true"', () => {
     it('should reject modal on click in .modalContainer', async () => {
-      const component = mount(ModalsDispatcher, {
-        global: {
-          plugins: [ModalsPlugin]
+      const component = factory(
+        {
+          global: {
+            plugins: [ModalsPlugin]
+          }
         }
-      });
+      );
 
       const modals = component.vm.$.appContext.provides.modals;
 
@@ -78,11 +89,13 @@ describe('rejectOnBackdrop', () => {
     });
 
     it('should reject modal on click in .modalContent', async () => {
-      const component = mount(ModalsDispatcher, {
-        global: {
-          plugins: [ModalsPlugin]
+      const component = factory(
+        {
+          global: {
+            plugins: [ModalsPlugin]
+          }
         }
-      });
+      );
 
       const modals = component.vm.$.appContext.provides.modals;
 
@@ -107,11 +120,13 @@ describe('rejectOnBackdrop', () => {
 
   describe('when "false"', () => {
     it('should not reject modal on click in .modalContainer', async () => {
-      const component = mount(ModalsDispatcher, {
-        global: {
-          plugins: [ModalsPlugin]
+      const component = factory(
+        {
+          global: {
+            plugins: [ModalsPlugin]
+          }
         }
-      });
+      );
 
       const modals = component.vm.$.appContext.provides.modals;
 
@@ -133,11 +148,13 @@ describe('rejectOnBackdrop', () => {
     });
 
     it('should not reject modal on click in .modalContent', async () => {
-      const component = mount(ModalsDispatcher, {
-        global: {
-          plugins: [ModalsPlugin]
+      const component = factory(
+        {
+          global: {
+            plugins: [ModalsPlugin]
+          }
         }
-      });
+      );
 
       const modals = component.vm.$.appContext.provides.modals;
 
@@ -161,11 +178,13 @@ describe('rejectOnBackdrop', () => {
 });
 
 it('should resolve modal when receive a resolve event from Modal', async () => {
-  const component = mount(ModalsDispatcher, {
-    global: {
-      plugins: [ModalsPlugin]
+  const component = factory(
+    {
+      global: {
+        plugins: [ModalsPlugin]
+      }
     }
-  });
+  );
 
   const modals = component.vm.$.appContext.provides.modals;
 
@@ -186,11 +205,13 @@ it('should resolve modal when receive a resolve event from Modal', async () => {
 });
 
 it('should reject modal when receive a reject event from Modal', async () => {
-  const component = mount(ModalsDispatcher, {
-    global: {
-      plugins: [ModalsPlugin]
+  const component = factory(
+    {
+      global: {
+        plugins: [ModalsPlugin]
+      }
     }
-  });
+  );
 
   const modals = component.vm.$.appContext.provides.modals;
 

--- a/tests/unit/modals-dispatcher.test.ts
+++ b/tests/unit/modals-dispatcher.test.ts
@@ -3,6 +3,10 @@ import { mount } from '@vue/test-utils';
 import ModalDispatcher from '../../lib/ModalsDispatcher.vue';
 import { ModalsPlugin } from '../../lib';
 
+function factory(config = {}) {
+  return mount(ModalDispatcher, config);
+}
+
 beforeEach(() => {
   document.body.innerHTML = '';
 });
@@ -12,7 +16,7 @@ it('should throw error when using component without installing Plugin', () => {
 
   console.error = jest.fn();
 
-  const component = mount(ModalDispatcher);
+  const component = factory();
 
   // @ts-ignore
   expect(console.error.mock.calls.length).toBe(1);
@@ -23,11 +27,9 @@ it('should throw error when using component without installing Plugin', () => {
 });
 
 it('should inject modalsIntances and teleport to body', async () => {
-  const component = mount(ModalDispatcher, {
-    global: {
-      plugins: [ModalsPlugin]
-    }
-  });
+  const component = factory({global: {
+    plugins: [ModalsPlugin]
+  }})
 
   const modals = component.vm.$.appContext.provides.modals;
 
@@ -41,11 +43,11 @@ it('should inject modalsIntances and teleport to body', async () => {
 });
 
 it('should react to modalsIntances dispose', async () => {
-  const component = mount(ModalDispatcher, {
+  const component = factory({ 
     global: {
-      plugins: [ModalsPlugin]
+      plugins: [ModalsPlugin],
     }
-  });
+  })
 
   const modals = component.vm.$.appContext.provides.modals;
 


### PR DESCRIPTION
Usar uma função de `factory` para criação de componentes permite reduzir quantidade de códigos repetidos